### PR TITLE
feat: Better concurrency handling

### DIFF
--- a/denops/@dpp-exts/installer.ts
+++ b/denops/@dpp-exts/installer.ts
@@ -6,21 +6,21 @@ import {
   type Plugin,
   type Protocol,
   type ProtocolName,
-} from "jsr:@shougo/dpp-vim@2.2.0/types";
+} from "jsr:@shougo/dpp-vim@~2.2.0/types";
 import {
   convert2List,
   isDirectory,
   printError,
   safeStat,
-} from "jsr:@shougo/dpp-vim@2.2.0/utils";
+} from "jsr:@shougo/dpp-vim@~2.2.0/utils";
 
-import type { Denops } from "jsr:@denops/std@~7.0.1";
-import * as autocmd from "jsr:@denops/std@7.0.3/autocmd";
-import * as op from "jsr:@denops/std@7.0.3/option";
-import * as fn from "jsr:@denops/std@7.0.3/function";
-import * as vars from "jsr:@denops/std@7.0.3/variable";
-import { expandGlob } from "jsr:@std/fs@1.0.1/expand-glob";
-import { delay } from "jsr:@std/async@1.0.3/delay";
+import type { Denops } from "jsr:@denops/std@~7.0.3";
+import * as autocmd from "jsr:@denops/std@~7.0.3/autocmd";
+import * as op from "jsr:@denops/std@~7.0.3/option";
+import * as fn from "jsr:@denops/std@~7.0.3/function";
+import * as vars from "jsr:@denops/std@~7.0.3/variable";
+import { expandGlob } from "jsr:@std/fs@~1.0.1/expand-glob";
+import { delay } from "jsr:@std/async@~1.0.3/delay";
 
 export type Params = {
   checkDiff: boolean;

--- a/denops/@dpp-exts/installer.ts
+++ b/denops/@dpp-exts/installer.ts
@@ -60,6 +60,7 @@ export type ExtActions<Params extends BaseActionParams> = {
   checkNotUpdated: Action<Params, void>;
   denoCache: Action<Params, void>;
   getNotInstalled: Action<Params, Plugin[]>;
+  getNotUpdated: Action<Params, Plugin[]>;
   getFailed: Action<Params, Plugin[]>;
   getLogs: Action<Params, string[]>;
   getUpdateLogs: Action<Params, string[]>;
@@ -67,7 +68,7 @@ export type ExtActions<Params extends BaseActionParams> = {
   install: Action<Params, void>;
   reinstall: Action<Params, void>;
   update: Action<Params, void>;
-}
+};
 
 export class Ext extends BaseExt<Params> {
   #failedPlugins: Plugin[] = [];


### PR DESCRIPTION
asyncutil's [`Semaphore`](https://jsr.io/@core/asyncutil/doc/semaphore/~/Semaphore) is well-tested and easy to use utility for concurrency.
This PR replaces the existing original implementation with it.