### PR TITLE
feat: Improve `checkNotUpdated` action

### DIFF
--- a/denops/@dpp-exts/installer.ts
+++ b/denops/@dpp-exts/installer.ts
@@ -1,13 +1,13 @@
-import {
-  type BaseParams,
-  type Context,
-  type DppOptions,
-  type ExtOptions,
-  type Plugin,
-  type ProtocolName,
+import type {
+  BaseParams,
+  Context,
+  DppOptions,
+  ExtOptions,
+  Plugin,
+  ProtocolName,
 } from "jsr:@shougo/dpp-vim@~3.0.0/types";
 import { type Action, BaseExt } from "jsr:@shougo/dpp-vim@~3.0.0/ext";
-import { type Protocol } from "jsr:@shougo/dpp-vim@~3.0.0/protocol";
+import type { Protocol } from "jsr:@shougo/dpp-vim@~3.0.0/protocol";
 import {
   convert2List,
   isDirectory,

--- a/denops/@dpp-exts/installer.ts
+++ b/denops/@dpp-exts/installer.ts
@@ -716,24 +716,16 @@ export class Ext extends BaseExt<Params> {
     }
 
     // Create query string.
-    const queries = [];
-    for (const [index, plugin] of plugins.entries()) {
-      if (!plugin.repo) {
-        continue;
-      }
-      const pluginNames = plugin.repo.split(/\//);
-      if (pluginNames.length !== 2) {
-        // Invalid repository name
-        continue;
-      }
-
-      // NOTE: "repository" API is faster than "search" API
-      queries.push(
-        `repo${index}: repository(owner:"${
-          pluginNames.slice(-2, -1)
-        }", name: "${pluginNames.slice(-1)}"){ pushedAt }`,
-      );
-    }
+    const query = "query {\n" +
+      [...plugins.entries()].flatMap(([index, plugin]) => {
+        if (!plugin.repo) return [];
+        const [owner, name] = extractGitHubRepo(plugin.repo) ?? [];
+        if (!owner || !name) return [];
+        // NOTE: "repository" API is faster than "search" API
+        return [
+          `repo${index}: repository(owner:"${owner}", name:"${name}"){ pushedAt }`,
+        ];
+      }).join("\n") + "\n}";
 
     // POST github API
     const resp = await fetch("https://api.github.com/graphql", {
@@ -742,20 +734,34 @@ export class Ext extends BaseExt<Params> {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${args.extParams.githubAPIToken}`,
       },
-      body: JSON.stringify({
-        query: `
-          query {
-            ${queries.join("\n")}
-          }
-        `,
-      }),
+      body: JSON.stringify({ query }),
     });
 
-    const respJson = (await resp.json()).data;
+    if (!resp.ok) {
+      await this.#printError(
+        args.denops,
+        args.extParams,
+        `Failed to fetch from GitHub GraphQL API: ${resp.statusText}`,
+      );
+      return [];
+    }
+
+    const result = await resp.json() as
+      | { data: Record<string, { pushedAt: string }> }
+      | { errors: { message: string }[] };
+
+    if ("errors" in result) {
+      await this.#printError(
+        args.denops,
+        args.extParams,
+        `Failed to fetch from GitHub GraphQL API: ${result.errors[0].message}`,
+      );
+      return [];
+    }
 
     return plugins.filter((_, index) =>
-      respJson[`repo${index}`]?.pushedAt &&
-      new Date(respJson[`repo${index}`].pushedAt) > baseUpdated
+      result.data[`repo${index}`]?.pushedAt &&
+      new Date(result.data[`repo${index}`].pushedAt) > baseUpdated
     );
   }
 
@@ -1099,4 +1105,18 @@ function pipeStream(
         },
       }),
     );
+}
+
+function extractGitHubRepo(repo: string): [string, string] | undefined {
+  if (repo.startsWith("https://github.com/")) {
+    const [owner, name] = repo.slice(19).split("/");
+    return [owner, name];
+  } else if (repo.startsWith("github.com/")) {
+    const [owner, name] = repo.slice(11).split("/");
+    return [owner, name];
+  }
+  const splitted = repo.split("/");
+  if (splitted.length === 2) {
+    return splitted as [string, string];
+  }
 }

--- a/doc/dpp-ext-installer.txt
+++ b/doc/dpp-ext-installer.txt
@@ -57,15 +57,14 @@ build
 
                                     *dpp-ext-installer-action-checkNotUpdated*
 checkNotUpdated
-		Check not updated or not installed plugins by github GraqhQL
-		API.
-		https://docs.github.com/en/graphql
-		NOTE: It is available for github plugins only.
+		Check not updated or not installed plugins by GitHub GraqhQL
+		API. (https://docs.github.com/en/graphql)
+		It does not return value but prompts whether update.
+		NOTE: It is available for GitHub plugins only.
 		NOTE: |dpp-ext-installer-param-githubAPIToken| must be set.
-		NOTE: It does not return value.
 		NOTE: The update check is quicker than
 		|dpp-ext-installer-action-update| but it is not perfect
-		solution. github API cannot detect upstream changes
+		solution. GitHub API cannot detect upstream changes
 		immediately.
 
 		params:
@@ -103,13 +102,13 @@ getNotInstalled
 
                                       *dpp-ext-installer-action-getNotUpdated*
 getNotUpdated
-		Get not updated plugins by github GraqhQL API.
+		Get not updated plugins by GitHub GraqhQL API.
 		https://docs.github.com/en/graphql.
-		NOTE: It is available for github plugins only.
+		NOTE: It is available for GitHub plugins only.
 		NOTE: |dpp-ext-installer-param-githubAPIToken| must be set.
 		NOTE: The update check is quicker than
 		|dpp-ext-installer-action-update| but it is not perfect
-		solution. github API cannot detect upstream changes
+		solution. GitHub API cannot detect upstream changes
 		immediately.
 
 		params:
@@ -214,9 +213,9 @@ enableDenoCache
 
                                       *dpp-ext-installer-param-githubAPIToken*
 githubAPIToken
-		Github API token for
-		|dpp-ext-installer-action-checkNotUpdated|.
-		NOTE: It only work for github plugins.
+		GitHub API token used for
+		|dpp-ext-installer-action-checkNotUpdated| and
+		|dpp-ext-installer-action-getNotUpdated|.
 
 		Defaults: ""
 


### PR DESCRIPTION
- The action now treat URL repo (starts with `(https://)?github.com/`) as GitHub plugin
- Handle HTTP error or GraphQL error and print its messages.