### PR TITLE
Add Codeberg support for update compare links

### DIFF
--- a/denops/@dpp-exts/installer/main.ts
+++ b/denops/@dpp-exts/installer/main.ts
@@ -1744,8 +1744,10 @@ async function loadCheckHistories(
 }
 
 function formatPlugin(updated: UpdatedPlugin): string {
+  const isSupportedHost = /^https?:\/\/(github\.com|codeberg\.org)\//.test(updated.url);
+
   const compareLink =
-    updated.oldRev !== "" && /^https?:\/\/github.com\//.test(updated.url)
+    updated.oldRev !== "" && isSupportedHost
       ? `\n    ${
         updated.url.replace(/\.git$/, "").replace(/^\w+:/, "https:")
       }/compare/${updated.oldRev}...${updated.newRev}`


### PR DESCRIPTION
I’m submitting this PR because I thought it would be great to see diff links on codeberg.org as well.