### PR TITLE
fix: Installation fails when the README directory exists

### DIFF
--- a/denops/@dpp-exts/installer/main.ts
+++ b/denops/@dpp-exts/installer/main.ts
@@ -1975,7 +1975,7 @@ async function checkInstalledFiles(
 
   let readmePath = "";
   for (const path of readmePaths) {
-    if (await safeStat(path)) {
+    if ((await safeStat(path))?.isFile) {
       readmePath = path;
       break;
     }


### PR DESCRIPTION
`checkInstalledFiles()` did not verify that the README path was a file, which could cause the installation to fail if a directory named "README" existed.
This has been fixed by using `await safeStat(path))?.isFile` to ensure that the path is confirmed to be a file.